### PR TITLE
Add HTTP protocol to make Docker Registry works with Ceph S3

### DIFF
--- a/s3/readme.md
+++ b/s3/readme.md
@@ -121,7 +121,7 @@ storage:
     bucket: docker-registry
     accesskey: XC5SVD9ZGQD0D0BG3J0H
     secretkey: uu3oqDZQjBFA22YqcuO4siuxecFVM0yYYHZ6COm4
-    regionendpoint: 192.168.59.1:80
+    regionendpoint: http://192.168.59.1:80
     secure: false
 http:
     addr: :6000


### PR DESCRIPTION
You need to add HTTP protocol in front of regionEndpoint to make it work